### PR TITLE
rip out sapine default per_page

### DIFF
--- a/lib/sapine.rb
+++ b/lib/sapine.rb
@@ -1,7 +1,6 @@
 require "sapine/version"
 
 module Sapine
-  DEFAULT_PER_PAGE = 20
 
   def self.included(base)
   end
@@ -20,7 +19,7 @@ module Sapine
     chain = sapine_add_order_by(chain, params[:order_by]) if params[:order_by]
 
     @_sapine_meta[:count] = chain.count
-    @_sapine_meta[:pages] = (@_sapine_meta[:count] / per_page.to_f).ceil
+    @_sapine_meta[:pages] = per_page ? (@_sapine_meta[:count] / per_page.to_f).ceil : 1
 
     chain = chain.limit(per_page)
     chain = chain.offset((params[:page].to_i - 1) * per_page) if params[:page].present? and params[:page].to_i > 0
@@ -36,7 +35,7 @@ module Sapine
   private
 
   def per_page
-    params[:per_page] ? params[:per_page].to_i : DEFAULT_PER_PAGE
+    params[:per_page] ? params[:per_page].to_i : nil
   end
 
   def sapine_add_order_by(chain, order_by)

--- a/lib/sapine/version.rb
+++ b/lib/sapine/version.rb
@@ -1,3 +1,3 @@
 module Sapine
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/spec/sapine_spec.rb
+++ b/spec/sapine_spec.rb
@@ -15,7 +15,7 @@ describe "Sapine" do
     end
 
     it "adds an order" do
-      @ws.stub(:params).and_return({order_by: "state"})
+      @ws.stub(:params).and_return({ order_by: "state" })
       chain = @ws.index_options(TestModel)
       chain.to_sql.include?("ORDER BY state").should be(true)
     end
@@ -26,22 +26,16 @@ describe "Sapine" do
       chain.to_sql.include?("ORDER BY state DESC").should be(true)
     end
 
-    it "adds the default limit" do
-      @ws.stub(:params).and_return({})
-      chain = @ws.index_options(TestModel)
-      chain.to_sql.should eql("SELECT  \"test_models\".* FROM \"test_models\"  LIMIT 20")
-    end
-
     it "adds a limit with a per_page" do
       @ws.stub(:params).and_return({per_page: 1})
       chain = @ws.index_options(TestModel)
-      chain.to_sql.should eql("SELECT  \"test_models\".* FROM \"test_models\"  LIMIT 1")
+      chain.to_sql.should eql("SELECT  \"test_models\".* FROM \"test_models\" LIMIT 1")
     end
 
     it "adds an offset with a page param" do
-      @ws.stub(:params).and_return({page: 2})
+      @ws.stub(:params).and_return({per_page: 20, page: 2})
       chain = @ws.index_options(TestModel)
-      chain.to_sql.should eql("SELECT  \"test_models\".* FROM \"test_models\"  LIMIT 20 OFFSET 20")
+      chain.to_sql.should eql("SELECT  \"test_models\".* FROM \"test_models\" LIMIT 20 OFFSET 20")
     end
 
     it "returns the count in api_meta" do


### PR DESCRIPTION
If there is no per_page defined in the params, do not paginate.
